### PR TITLE
Faster byte-to-hex and other fun stuff

### DIFF
--- a/PerformanceStubs/PerformanceStubs.csproj
+++ b/PerformanceStubs/PerformanceStubs.csproj
@@ -24,6 +24,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <PlatformTarget>x86</PlatformTarget>
@@ -33,6 +34,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FastMember, Version=1.0.0.9, Culture=neutral, processorArchitecture=MSIL">

--- a/PerformanceStubs/Tests/ConvertByteArrayToHexString/Test.cs
+++ b/PerformanceStubs/Tests/ConvertByteArrayToHexString/Test.cs
@@ -166,10 +166,10 @@
             return Encoding.ASCII.GetBytes("put any sample string you want to test here instead of a file");
         }
 
-        private static readonly byte[] input = GenerateTestInput();
+        private byte[] _Intput1 = null;
         protected override byte[] Input1 {
             get {
-                return input;
+                return _Intput1 ?? (_Intput1 = GenerateTestInput());
             }
         }
         protected override long Iterations {

--- a/PerformanceStubs/Tests/ConvertByteArrayToHexString/Test.cs
+++ b/PerformanceStubs/Tests/ConvertByteArrayToHexString/Test.cs
@@ -3,11 +3,12 @@
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Runtime.InteropServices;
     using System.Runtime.Remoting.Metadata.W3cXsd2001;
     using System.Text;
     using PerformanceStubs.Core;
 
-    public class Test: PerformanceTestOneInOneOut<byte[], string> {
+    public unsafe class Test: PerformanceTestOneInOneOut<byte[], string> {
         protected override string Title {
             get {
                 return "Converting array of bytes into hexadecimal string representation";
@@ -34,6 +35,7 @@
                     ByteArrayToHexViaLookupAndShift,
                     ByteArrayToHexViaLookup,
                     ByteArrayToHexViaLookupPerByte,
+                    ByteArrayToHexViaLookup32UnsafeDirect,
                 }).ToList();
             }
         }
@@ -94,9 +96,10 @@
             SoapHexBinary soapHexBinary = new SoapHexBinary(bytes);
             return soapHexBinary.ToString();
         }
+
+        const string hexAlphabet = "0123456789ABCDEF";
         static string ByteArrayToHexViaLookupAndShift(byte[] bytes) {
             StringBuilder result = new StringBuilder(bytes.Length * 2);
-            string hexAlphabet = "0123456789ABCDEF";
             foreach (byte b in bytes) {
                 result.Append(hexAlphabet[(int)(b >> 4)]);
                 result.Append(hexAlphabet[(int)(b & 0xF)]);
@@ -120,25 +123,10 @@
             }
             return new string(result);
         }
+
+        // { "00", "01", ..., "0E", "0F", "10", "11", ..., "FE", "FF" }
+        static readonly string[] hexStringTable = hexAlphabet.SelectMany(n1 => hexAlphabet.Select(n2 => new string(new[] { n1, n2 }))).ToArray();
         static string ByteArrayToHexViaLookup(byte[] bytes) {
-            string[] hexStringTable = new string[] {
-                "00", "01", "02", "03", "04", "05", "06", "07", "08", "09", "0A", "0B", "0C", "0D", "0E", "0F",
-                "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "1A", "1B", "1C", "1D", "1E", "1F",
-                "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "2A", "2B", "2C", "2D", "2E", "2F",
-                "30", "31", "32", "33", "34", "35", "36", "37", "38", "39", "3A", "3B", "3C", "3D", "3E", "3F",
-                "40", "41", "42", "43", "44", "45", "46", "47", "48", "49", "4A", "4B", "4C", "4D", "4E", "4F",
-                "50", "51", "52", "53", "54", "55", "56", "57", "58", "59", "5A", "5B", "5C", "5D", "5E", "5F",
-                "60", "61", "62", "63", "64", "65", "66", "67", "68", "69", "6A", "6B", "6C", "6D", "6E", "6F",
-                "70", "71", "72", "73", "74", "75", "76", "77", "78", "79", "7A", "7B", "7C", "7D", "7E", "7F",
-                "80", "81", "82", "83", "84", "85", "86", "87", "88", "89", "8A", "8B", "8C", "8D", "8E", "8F",
-                "90", "91", "92", "93", "94", "95", "96", "97", "98", "99", "9A", "9B", "9C", "9D", "9E", "9F",
-                "A0", "A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8", "A9", "AA", "AB", "AC", "AD", "AE", "AF",
-                "B0", "B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9", "BA", "BB", "BC", "BD", "BE", "BF",
-                "C0", "C1", "C2", "C3", "C4", "C5", "C6", "C7", "C8", "C9", "CA", "CB", "CC", "CD", "CE", "CF",
-                "D0", "D1", "D2", "D3", "D4", "D5", "D6", "D7", "D8", "D9", "DA", "DB", "DC", "DD", "DE", "DF",
-                "E0", "E1", "E2", "E3", "E4", "E5", "E6", "E7", "E8", "E9", "EA", "EB", "EC", "ED", "EE", "EF",
-                "F0", "F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "FA", "FB", "FC", "FD", "FE", "FF",
-            };
             StringBuilder result = new StringBuilder(bytes.Length * 2);
             foreach (byte b in bytes) {
                 result.Append(hexStringTable[b]);
@@ -146,25 +134,42 @@
             return result.ToString();
         }
 
-        static byte[] GetSource(string fileName) {
-            FileInfo testSubjectFile = new System.IO.FileInfo(fileName);
-            string testFileContents = null;
-            using (FileStream testSubjectStream = testSubjectFile.OpenRead()) {
-                using (StreamReader testSubjectReader = new StreamReader(testSubjectStream)) {
-                    testFileContents = testSubjectReader.ReadToEnd();
+        static readonly uint* _lookup32UnsafeP = (uint*)GCHandle.Alloc(_Lookup32, GCHandleType.Pinned).AddrOfPinnedObject();
+        static string ByteArrayToHexViaLookup32UnsafeDirect(byte[] bytes)
+        {
+            var lookupP = _lookup32UnsafeP;
+            var result = new string((char)0, bytes.Length * 2);
+            fixed (byte* bytesP = bytes)
+            fixed (char* resultP = result)
+            {
+                uint* resultP2 = (uint*)resultP;
+                for (int i = 0; i < bytes.Length; i++)
+                {
+                    resultP2[i] = lookupP[bytesP[i]];
                 }
             }
-            return System.Text.ASCIIEncoding.ASCII.GetBytes(testFileContents);
+
+            return result;
+        }
+
+        static byte[] GetSource(string fileName) {
+            FileInfo testSubjectFile = new FileInfo(fileName);
+            using (FileStream testSubjectStream = testSubjectFile.OpenRead()) {
+                using (StreamReader testSubjectReader = new StreamReader(testSubjectStream)) {
+                    return Encoding.ASCII.GetBytes(testSubjectReader.ReadToEnd());
+                }
+            }
         }
         private static byte[] GenerateTestInput() {
             //return GetSource(@"Tests\ConvertByteArrayToHexString\SmallText.txt");
             //return GetSource(@"Tests\ConvertByteArrayToHexString\LargeText.txt");
-            return System.Text.ASCIIEncoding.ASCII.GetBytes("put any sample string you want to test here instead of a file");
+            return Encoding.ASCII.GetBytes("put any sample string you want to test here instead of a file");
         }
-        private byte[] _Intput1 = null;
+
+        private static readonly byte[] input = GenerateTestInput();
         protected override byte[] Input1 {
             get {
-                return _Intput1 ?? (_Intput1 = GenerateTestInput());
+                return input;
             }
         }
         protected override long Iterations {

--- a/PerformanceStubs/Tests/ListFirstSubtypeItem/Test.cs
+++ b/PerformanceStubs/Tests/ListFirstSubtypeItem/Test.cs
@@ -19,7 +19,10 @@
             get {
                 return (new Func<IEnumerable<Something>, SubSomething>[] {
                     FirstOrDefaultAs,
-                    SelectAsWhereNotNullFirstOrDefault
+                    SelectAsWhereNotNullFirstOrDefault,
+                    SelectAsFirstOrDefaultNotNull,
+                    OfTypeFirstOrDefault,
+                    SimpleLoop,
                 }).ToList();
             }
         }
@@ -28,6 +31,24 @@
         }
         public static SubSomething SelectAsWhereNotNullFirstOrDefault(IEnumerable<Something> source) {
             return source.Select(item => item as SubSomething).Where(item => item != null).FirstOrDefault();
+        }
+        public static SubSomething SelectAsFirstOrDefaultNotNull(IEnumerable<Something> source) {
+            return source.Select(item => item as SubSomething).FirstOrDefault(item => item != null);
+        }
+        public static SubSomething OfTypeFirstOrDefault(IEnumerable<Something> source) {
+            return source.OfType<SubSomething>().FirstOrDefault();
+        }
+        public static SubSomething SimpleLoop(IEnumerable<Something> source) {
+            foreach (Something val in source)
+            {
+                SubSomething subVal = val as SubSomething;
+                if (subVal != null)
+                {
+                    return subVal;
+                }
+            }
+
+            return null;
         }
 
         private static IEnumerable<Something> GenerateTestInput() {
@@ -44,7 +65,7 @@
         private IEnumerable<Something> _Intput1 = null;
         protected override IEnumerable<Something> Input1 {
             get {
-                return _Intput1 ?? (_Intput1 = GenerateTestInput());
+                return _Intput1 ?? (_Intput1 = GenerateTestInput().Skip(0));
             }
         }
         protected override long Iterations {


### PR DESCRIPTION
The main purpose of me looking into this was to add CodesInChaos's unsafe variant of his byte-to-hex lookup method that runs significantly faster than the safe version (on SmallText, this was 171.87 average ticks for unsafe compared to 235.47 ticks for lookup-per-byte... 105.9x vs 77.3x since the worst one that run was 18194.17 ticks).  While I was in there, I also added:

- forced amortization of costs on the different byte-to-hex variants that would be amortized in practice, such as creating lookup tables.
- dynamically generating the hex string table using some really fun LINQ, which seemed fair game because that's how _Lookup32 is generated.
- super minor cleanups.

I also took a look at the other tests and added some thoughts of my own... it's all in the commit messages, but might as well point it out here:

- since the casting stuff is literally just looking at different ways of reimplementing .OfType&lt;T&gt;(), I figured we might as well put .OfType&lt;T&gt;() in there to see how well it performs... turns out, better than some of the other ones here.
- figured I'd add at least one in each LINQ-based test that does away with the projection operators and just does a simple loop.
- fixing an oversight in the entire-sequence casting test that causes it to just test how quickly we can *create* the sequence, rather than anything that actually manipulates the sequence... this also meant dropping down the iteration count for the same reason I suspect you did it on the other similar test.
- leveling the playing field for all of the casting tests by calling .Skip(0) on the list we return, as LINQ sometimes special-cases List&lt;T&gt; sources by doing different things that give anything that starts with .Select(x) or .Where(x) an unfair advantage over anything that doesn't.
- calling the built-in SequenceEqual method for equality comparison on the entire-sequence casting test, instead of reimplementing it inefficiently.

I also tried improving the test for getting object properties by name, but by the time I was done, I discovered that I had just reimplemented FastMember, just in a less general-purpose way, so I backed off on that one.  It was super cool, but then again, so is FastMember...

Note that I had to make some changes to the project file to make it compile in my MonoDevelop environment... I backed them all out except for the couple of lines required to make unsafe blocks OK to use, but that means I wasn't able to directly test the code here.  Let me know if it doesn't build for you, or breaks for some other reason, and I'll try to help make it work for you.  I'd normally use Visual Studio Community, but that PC is out for repairs so I'm in an Arch Linux VirtualBox on a different PC (which is actually why I looked into your project at all... I'm incredibly bored... but this is like a tangent on another tangent, so I'll stop writing now).